### PR TITLE
Feature/new bucket functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ python download_from_s3.py nombre_archivo nombre_bucket --destination-path /home
   El primer parámetro es el nombre del archivo a descargar, el segundo corresponde al nombre del bucket en que se 
   encuentra el archivo, y por último, existe un parámetro opcional que permite definir la ruta donde se guardará el 
   archivo, si es omitido el archivo será guardado en el `current working directory` (dado por `os.getcwd()`)
-  
+
  #### Ayuda
 ```
 # consultar ayuda
@@ -133,6 +133,55 @@ optional arguments:
   --destination-path DESTINATION_PATH
                         path where files will be saved, if it is not provided
                         we will use current path
+
+```
+### Comando delete_bucket_from_s3.py
+```
+python delete_bucket_from_s3.py nombre_bucket
+```
+El parámetro es el nombre del bucket a eliminar. Este comando eliminará el bucket junto a todos sus archivos
+
+```
+usage: delete_bucket_from_s3.py [-h] bucket_name
+
+delete S3 bucket
+
+positional arguments:
+  bucket_name  bucket name
+
+optional arguments:
+  -h, --help   show this help message and exit
+```
+
+### Comando move_bucket_from_s3.py
+```
+python move_bucket_from_s3.py bucket_origen bucket_destino --filename nombre_archivo --extension filtro_de_extensiones
+```
+
+El primer parámetros es el bucket desde donde se copiarán los archivos. El segundo comando es el bucket al que se copiarán los archivos.
+El parámetro opcional nombre_archivo es para solo mover uno o más archivos según nombre de archivo. El último parámetro opcional, 
+filtro_de_extensiones, permite mover los archivos que solo contengan las extensiones indicadas. Ej: .viajes
+
+
+ #### Ayuda
+```
+# consultar ayuda
+usage: move_bucket_from_s3.py [-h] [-f [FILENAME [FILENAME ...]]] [-e [EXTENSION_FILTER [EXTENSION_FILTER ...]]]
+                              source_bucket target_bucket
+
+move one or more objects from source S3 bucket to target S3 bucket
+
+positional arguments:
+  source_bucket         source bucket name
+  target_bucket         target bucket name
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -f [FILENAME [FILENAME ...]], --filename [FILENAME [FILENAME ...]]
+                        one or more filenames
+  -e [EXTENSION_FILTER [EXTENSION_FILTER ...]], --extension [EXTENSION_FILTER [EXTENSION_FILTER ...]]
+                        only files with this extension will be moved
+
 
 ```
  

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ optional arguments:
 python move_bucket_from_s3.py bucket_origen bucket_destino --filename nombre_archivo --extension filtro_de_extensiones
 ```
 
-El primer parámetros es el bucket desde donde se copiarán los archivos. El segundo comando es el bucket al que se copiarán los archivos.
+El primer parámetro es el bucket desde donde se copiarán los archivos. El segundo comando es el bucket al que se copiarán los archivos.
 El parámetro opcional nombre_archivo es para solo mover uno o más archivos según nombre de archivo. El último parámetro opcional, 
 filtro_de_extensiones, permite mover los archivos que solo contengan las extensiones indicadas. Ej: .viajes
 

--- a/aws.py
+++ b/aws.py
@@ -163,3 +163,4 @@ def filter_by_extension(file_list: list, extension_list: list) -> list:
         list: filtered list
     """
     return [file for file in file_list if any(ext in pathlib.Path(file).suffixes for ext in extension_list)]
+

--- a/aws.py
+++ b/aws.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import urllib
 
@@ -16,6 +17,7 @@ class AWSSession:
         self.session = boto3.Session(
             aws_access_key_id=config('AWS_ACCESS_KEY_ID'),
             aws_secret_access_key=config('AWS_SECRET_ACCESS_KEY'))
+        self.logger = logging.getLogger(__name__)
 
     def retrieve_obj_list(self, bucket_name):
         s3 = self.session.resource('s3')
@@ -123,7 +125,7 @@ class AWSSession:
             for file in datafiles:
                 self.copy_file_from_bucket_to_bucket(source_bucket_name, target_bucket_name, file)
                 self.delete_object_in_bucket(file, source_bucket_name)
-                print(f"{file} moved from {source_bucket_name} to {target_bucket_name}")
+                self.logger.info(f"{file} moved from {source_bucket_name} to {target_bucket_name}")
         else:
             if extension_list:
                 datafiles = filter_by_extension(datafiles, extension_list)
@@ -131,9 +133,9 @@ class AWSSession:
                 if self.check_file_exists(source_bucket_name, file_name):
                     self.copy_file_from_bucket_to_bucket(source_bucket_name, target_bucket_name, file_name)
                     self.delete_object_in_bucket(file_name, source_bucket_name)
-                    print(f"{file_name} moved from {source_bucket_name} to {target_bucket_name}")
+                    self.logger.info(f"{file_name} moved from {source_bucket_name} to {target_bucket_name}")
                 else:
-                    print(f"{file_name} does not exist in {source_bucket_name}")
+                    self.logger.info(f"{file_name} does not exist in {source_bucket_name}")
 
     def delete_bucket(self, bucket_name: str) -> None:
         """
@@ -146,10 +148,10 @@ class AWSSession:
         bucket = s3.Bucket(bucket_name)
         for file in bucket.objects.all():
             self.delete_object_in_bucket(file.key, bucket_name)
-            print(f"{file.key} deleted")
+            self.logger.info(f"{file.key} deleted")
 
         client.delete_bucket(Bucket=bucket_name)
-        print(f"{bucket_name} deleted")
+        self.logger.info(f"{bucket_name} deleted")
 
 
 def filter_by_extension(file_list: list, extension_list: list) -> list:

--- a/delete_bucket_from_s3.py
+++ b/delete_bucket_from_s3.py
@@ -1,0 +1,42 @@
+import argparse
+import os
+import sys
+
+from botocore.exceptions import ClientError
+
+# add path so we can use function through command line
+new_path = os.path.join(os.path.dirname(__file__), '..', '..')
+sys.path.append(new_path)
+
+from aws import AWSSession
+
+
+def main(argv):
+    """
+    This script will delete a S3 bucket.
+    """
+
+    # Arguments and description
+    parser = argparse.ArgumentParser(description='delete S3 bucket')
+
+    parser.add_argument('bucket_name', help='bucket name')
+
+    args = parser.parse_args(argv[1:])
+
+    # Give names to arguments
+    bucket_name = args.bucket_name
+
+    aws_session = AWSSession()
+
+    if not aws_session.check_bucket_exists(bucket_name):
+        print(f"Bucket {bucket_name} does not exist")
+        exit(1)
+
+    try:
+        aws_session.delete_bucket(bucket_name)
+    except ClientError as e:
+        print(e)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/delete_bucket_from_s3.py
+++ b/delete_bucket_from_s3.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import sys
 
@@ -27,15 +28,17 @@ def main(argv):
     bucket_name = args.bucket_name
 
     aws_session = AWSSession()
+    logger = logging.getLogger(__name__)
+    logging.basicConfig(level=logging.INFO)
 
     if not aws_session.check_bucket_exists(bucket_name):
-        print(f"Bucket {bucket_name} does not exist")
+        logger.info(f"Bucket {bucket_name} does not exist")
         exit(1)
 
     try:
         aws_session.delete_bucket(bucket_name)
     except ClientError as e:
-        print(e)
+        logger.error(e)
 
 
 if __name__ == "__main__":

--- a/delete_object_in_s3.py
+++ b/delete_object_in_s3.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import sys
 
@@ -28,17 +29,19 @@ def main(argv):
     bucket_name = args.bucket
 
     aws_session = AWSSession()
+    logger = logging.getLogger(__name__)
+    logging.basicConfig(level=logging.INFO)
 
     if not aws_session.check_bucket_exists(bucket_name):
-        print('Bucket \'{0}\' does not exist'.format(bucket_name))
+        logger.info(f"Bucket {bucket_name} does not exist")
         exit(1)
 
     try:
         aws_session.delete_object_in_bucket(filename, bucket_name)
-        print('Object {0} was deleted successfully!'.format(filename))
+        logger.info(f"Object {filename} was deleted successfully!")
     except ClientError as e:
         # ignore it and continue uploading files
-        print(e)
+        logger.error(e)
 
 
 if __name__ == "__main__":

--- a/download_from_s3.py
+++ b/download_from_s3.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import sys
 
@@ -30,26 +31,28 @@ def main(argv):
     datafiles = args.filename
     bucket_name = args.bucket
     destination_path = args.destination_path
+    logger = logging.getLogger(__name__)
+    logging.basicConfig(level=logging.INFO)
 
     if destination_path is not None and not os.path.isdir(destination_path):
-        print('Path \'{0}\' is not valid'.format(destination_path))
+        logger.info(f"Path \'{destination_path}\' is not valid")
         exit(1)
 
     aws_session = AWSSession()
 
     if not aws_session.check_bucket_exists(bucket_name):
-        print('Bucket \'{0}\' does not exist'.format(bucket_name))
+        logger.info(f"Bucket \'{bucket_name}\' does not exist")
         exit(1)
 
     for datafile in datafiles:
         filename = datafile
         if destination_path is not None:
             filename = os.path.join(destination_path, datafile)
-        print('downloading object {0} ...'.format(datafile))
+        logger.info(f"downloading object {datafile} ...")
         try:
             aws_session.download_object_from_bucket(datafile, bucket_name, filename)
         except ClientError as e:
-            print(e)
+            logger.error(e)
 
 
 if __name__ == "__main__":

--- a/move_bucket_from_s3.py
+++ b/move_bucket_from_s3.py
@@ -1,0 +1,51 @@
+import argparse
+import os
+import sys
+
+from botocore.exceptions import ClientError
+
+# add path so we can use function through command line
+new_path = os.path.join(os.path.dirname(__file__), '..', '..')
+sys.path.append(new_path)
+
+from aws import AWSSession
+
+
+def main(argv):
+    """
+    This script will move one or more objects from S3 bucket to another S3 bucket.
+    """
+
+    # Arguments and description
+    parser = argparse.ArgumentParser(description='move one or more objects from source S3 bucket to target S3 bucket')
+
+    parser.add_argument('source_bucket', help='source bucket name')
+    parser.add_argument('target_bucket', help='target bucket name')
+    parser.add_argument('filename',  default=None, nargs='?', help='one or more filenames')
+    parser.add_argument('extension_filter', default=None, help='only files with this extension will be moved')
+
+    args = parser.parse_args(argv[1:])
+
+    # Give names to arguments
+    source_bucket_name = args.source_bucket
+    target_bucket_name = args.target_bucket
+    datafiles = args.filename if args.filename else None
+    extension = args.extension_filter
+
+    aws_session = AWSSession()
+
+    if not aws_session.check_bucket_exists(source_bucket_name):
+        print(f"Bucket {source_bucket_name} does not exist")
+        exit(1)
+
+    if not aws_session.check_bucket_exists(target_bucket_name):
+        print(f"Bucket {target_bucket_name} does not exist")
+        exit(1)
+    try:
+        aws_session.move_files_from_bucket_to_bucket(source_bucket_name, target_bucket_name, datafiles, extension)
+    except ClientError as e:
+        print(e)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/move_bucket_from_s3.py
+++ b/move_bucket_from_s3.py
@@ -35,19 +35,20 @@ def main(argv):
     extension = args.extension_filter
 
     aws_session = AWSSession()
+    logger = logging.getLogger(__name__)
     logging.basicConfig(level=logging.INFO)
 
     if not aws_session.check_bucket_exists(source_bucket_name):
-        aws_session.logger.info(f"Bucket {source_bucket_name} does not exist")
+        logger.info(f"Bucket {source_bucket_name} does not exist")
         exit(1)
 
     if not aws_session.check_bucket_exists(target_bucket_name):
-        aws_session.logger.info(f"Bucket {target_bucket_name} does not exist")
+        logger.info(f"Bucket {target_bucket_name} does not exist")
         exit(1)
     try:
         aws_session.move_files_from_bucket_to_bucket(source_bucket_name, target_bucket_name, datafiles, extension)
     except ClientError as e:
-        aws_session.logger.error(e)
+        logger.error(e)
 
 
 if __name__ == "__main__":

--- a/move_bucket_from_s3.py
+++ b/move_bucket_from_s3.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import sys
 
@@ -34,18 +35,19 @@ def main(argv):
     extension = args.extension_filter
 
     aws_session = AWSSession()
+    logging.basicConfig(level=logging.INFO)
 
     if not aws_session.check_bucket_exists(source_bucket_name):
-        print(f"Bucket {source_bucket_name} does not exist")
+        aws_session.logger.info(f"Bucket {source_bucket_name} does not exist")
         exit(1)
 
     if not aws_session.check_bucket_exists(target_bucket_name):
-        print(f"Bucket {target_bucket_name} does not exist")
+        aws_session.logger.info(f"Bucket {target_bucket_name} does not exist")
         exit(1)
     try:
         aws_session.move_files_from_bucket_to_bucket(source_bucket_name, target_bucket_name, datafiles, extension)
     except ClientError as e:
-        print(e)
+        aws_session.logger.error(e)
 
 
 if __name__ == "__main__":

--- a/move_bucket_from_s3.py
+++ b/move_bucket_from_s3.py
@@ -21,15 +21,16 @@ def main(argv):
 
     parser.add_argument('source_bucket', help='source bucket name')
     parser.add_argument('target_bucket', help='target bucket name')
-    parser.add_argument('filename',  default=None, nargs='?', help='one or more filenames')
-    parser.add_argument('extension_filter', default=None, help='only files with this extension will be moved')
+    parser.add_argument('-f', '--filename', dest='filename', default=None, nargs='*', help='one or more filenames')
+    parser.add_argument('-e', dest='extension_filter', default=None, nargs='*',
+                        help='only files with this extension will be moved')
 
     args = parser.parse_args(argv[1:])
 
     # Give names to arguments
     source_bucket_name = args.source_bucket
     target_bucket_name = args.target_bucket
-    datafiles = args.filename if args.filename else None
+    datafiles = args.filename
     extension = args.extension_filter
 
     aws_session = AWSSession()

--- a/move_bucket_from_s3.py
+++ b/move_bucket_from_s3.py
@@ -22,7 +22,7 @@ def main(argv):
     parser.add_argument('source_bucket', help='source bucket name')
     parser.add_argument('target_bucket', help='target bucket name')
     parser.add_argument('-f', '--filename', dest='filename', default=None, nargs='*', help='one or more filenames')
-    parser.add_argument('-e', dest='extension_filter', default=None, nargs='*',
+    parser.add_argument('-e', '--extension', dest='extension_filter', default=None, nargs='*',
                         help='only files with this extension will be moved')
 
     args = parser.parse_args(argv[1:])

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ boto3==1.9.88
 botocore==1.12.89
 coverage==4.5.3
 python-coveralls==2.9.3
-mock==4.0.2

--- a/test/testAws.py
+++ b/test/testAws.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
+from unittest import mock
 
-import mock
 from botocore.exceptions import ClientError
 
 import aws
@@ -151,7 +151,7 @@ class AwsTest(TestCase):
         bucket = mock.MagicMock()
         bucket.Bucket.return_value = mock.MagicMock(objects=object_bucket)
         self.aws_session.session.resource = mock.MagicMock(return_value=bucket)
-        self.aws_session.copy_file_from_bucket_to_bucket= mock.MagicMock()
+        self.aws_session.copy_file_from_bucket_to_bucket = mock.MagicMock()
         self.aws_session.delete_object_in_bucket = mock.MagicMock()
         self.aws_session.move_files_from_bucket_to_bucket(source_bucket_name, target_bucket_name, datafiles,
                                                           extension_list)
@@ -167,6 +167,6 @@ class AwsTest(TestCase):
                                                           extension_list)
 
         # one file does not exist case
-        self.aws_session.check_file_exists = mock.MagicMock(return_value = False)
+        self.aws_session.check_file_exists = mock.MagicMock(return_value=False)
         self.aws_session.move_files_from_bucket_to_bucket(source_bucket_name, target_bucket_name, datafiles,
                                                           extension_list)

--- a/test/testAws.py
+++ b/test/testAws.py
@@ -107,3 +107,24 @@ class AwsTest(TestCase):
         bucket.Bucket.return_value = bucket
         self.aws_session.session.resource = mock.MagicMock(return_value=bucket)
         self.aws_session.download_object_from_bucket('key', 'name', 'path')
+
+    def test_copy_files_from_bucket_to_bucket(self):
+        target_bucket = mock.MagicMock(copy=mock.MagicMock())
+        target_bucket.Bucket.return_value = target_bucket
+        self.aws_session.session.resource = mock.MagicMock(return_value=target_bucket)
+        self.aws_session.copy_files_from_bucket_to_bucket('source_bucket', 'target_bucket', 'file_name')
+
+    def test_filter_by_extension(self):
+        file_list = ['2020-01-01.trip.gz', '2020-01-01.viajes.gz']
+        expected_list = ['2020-01-01.trip.gz']
+        extension = ['.trip']
+        self.assertEqual(expected_list, aws.filter_by_extension(file_list, extension))
+
+        file_list = ['2020-01-01.trip.gz', '2020-01-01.viajes.gz']
+        extension = ['.trip', '.viajes']
+        self.assertEqual(file_list, aws.filter_by_extension(file_list, extension))
+
+        file_list = ['2020-01-01.trip.gz', '2020-01-01.viajes.gz', '2020-01-01.trip', '2020-01-01.viajes']
+        expected_list = ['2020-01-01.trip.gz', '2020-01-01.trip']
+        extension = ['.trip']
+        self.assertEqual(expected_list, aws.filter_by_extension(file_list, extension))

--- a/test/testAws.py
+++ b/test/testAws.py
@@ -112,7 +112,7 @@ class AwsTest(TestCase):
         target_bucket = mock.MagicMock(copy=mock.MagicMock())
         target_bucket.Bucket.return_value = target_bucket
         self.aws_session.session.resource = mock.MagicMock(return_value=target_bucket)
-        self.aws_session.copy_files_from_bucket_to_bucket('source_bucket', 'target_bucket', 'file_name')
+        self.aws_session.copy_file_from_bucket_to_bucket('source_bucket', 'target_bucket', 'file_name')
 
     def test_filter_by_extension(self):
         file_list = ['2020-01-01.trip.gz', '2020-01-01.viajes.gz']
@@ -128,3 +128,14 @@ class AwsTest(TestCase):
         expected_list = ['2020-01-01.trip.gz', '2020-01-01.trip']
         extension = ['.trip']
         self.assertEqual(expected_list, aws.filter_by_extension(file_list, extension))
+
+    def test_delete_bucket(self):
+        file_list = [mock.MagicMock(key='2020-01-01.trip.gz')]
+        object_bucket = mock.MagicMock(all=mock.MagicMock(return_value=file_list))
+        bucket = mock.MagicMock()
+        bucket.Bucket.return_value = mock.MagicMock(objects=object_bucket)
+        self.aws_session.session.resource = mock.MagicMock(return_value=bucket)
+        client = mock.MagicMock(delete_bucket=mock.MagicMock())
+        self.aws_session.session.client = mock.MagicMock(return_value=client)
+        self.aws_session.delete_object_in_bucket = mock.MagicMock()
+        self.aws_session.delete_bucket('bucket_name')

--- a/test/testAws.py
+++ b/test/testAws.py
@@ -139,3 +139,34 @@ class AwsTest(TestCase):
         self.aws_session.session.client = mock.MagicMock(return_value=client)
         self.aws_session.delete_object_in_bucket = mock.MagicMock()
         self.aws_session.delete_bucket('bucket_name')
+
+    def test_move_files_from_bucket_to_bucket(self):
+        # all files case
+        source_bucket_name = 'source'
+        target_bucket_name = 'target'
+        datafiles = []
+        extension_list = ['.trip']
+        file_list = [mock.MagicMock(key='2020-01-01.trip.gz')]
+        object_bucket = mock.MagicMock(all=mock.MagicMock(return_value=file_list))
+        bucket = mock.MagicMock()
+        bucket.Bucket.return_value = mock.MagicMock(objects=object_bucket)
+        self.aws_session.session.resource = mock.MagicMock(return_value=bucket)
+        self.aws_session.copy_file_from_bucket_to_bucket= mock.MagicMock()
+        self.aws_session.delete_object_in_bucket = mock.MagicMock()
+        self.aws_session.move_files_from_bucket_to_bucket(source_bucket_name, target_bucket_name, datafiles,
+                                                          extension_list)
+        # one file case
+        datafiles = ['2020-01-01.trip.gz']
+        object_bucket = mock.MagicMock(all=mock.MagicMock(return_value=file_list))
+        bucket = mock.MagicMock()
+        bucket.Bucket.return_value = mock.MagicMock(objects=object_bucket)
+        self.aws_session.session.resource = mock.MagicMock(return_value=bucket)
+        self.aws_session.copy_file_from_bucket_to_bucket = mock.MagicMock()
+        self.aws_session.delete_object_in_bucket = mock.MagicMock()
+        self.aws_session.move_files_from_bucket_to_bucket(source_bucket_name, target_bucket_name, datafiles,
+                                                          extension_list)
+
+        # one file does not exist case
+        self.aws_session.check_file_exists = mock.MagicMock(return_value = False)
+        self.aws_session.move_files_from_bucket_to_bucket(source_bucket_name, target_bucket_name, datafiles,
+                                                          extension_list)

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -378,7 +378,7 @@ class DeleteBucketTest(TestCase):
             delete_bucket_main([self.command_name, bucket_name])
 
         expected_answer = 'ERROR:delete_bucket_from_s3:An error occurred (403) when calling the deleting operation: ' \
-                          'forbidden '
+                          'forbidden'
         self.assertIn(expected_answer, f.output)
 
         delete_bucket.assert_called_once()
@@ -428,7 +428,7 @@ class MoveBucketTest(TestCase):
             move_bucket_main([self.command_name, source, target])
 
         expected_answer = 'ERROR:move_bucket_from_s3:An error occurred (403) when calling the moving operation: ' \
-                          'forbidden '
+                          'forbidden'
         self.assertIn(expected_answer, f.output)
 
         move_files_from_bucket_to_bucket.assert_called_once()

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -35,12 +35,12 @@ class DeleteObjectTest(TestCase):
         filename = 'aaa.txt'
         bucket_name = 'aarrrp'
 
-        f = io.StringIO()
-        with redirect_stdout(f):
+        with self.assertLogs('delete_object_in_s3', level='INFO') as f:
             with self.assertRaises(SystemExit):
                 delete_main([self.command_name, filename, bucket_name])
 
-        self.assertIn('Bucket \'{0}\' does not exist'.format(bucket_name), f.getvalue())
+        expected_answer = 'INFO:delete_object_in_s3:Bucket aarrrp does not exist'
+        self.assertIn(expected_answer, f.output)
 
     @mock.patch('delete_object_in_s3.AWSSession')
     def test_bucket_is_deleted(self, aws_session_mock):
@@ -51,11 +51,11 @@ class DeleteObjectTest(TestCase):
         filename = 'aaa.txt'
         bucket_name = 'aarrrp'
 
-        f = io.StringIO()
-        with redirect_stdout(f):
+        with self.assertLogs('delete_object_in_s3', level='INFO') as f:
             delete_main([self.command_name, filename, bucket_name])
 
-        self.assertIn('Object {0} was deleted successfully!'.format(filename), f.getvalue())
+        expected_answer = 'INFO:delete_object_in_s3:Object aaa.txt was deleted successfully!'
+        self.assertIn(expected_answer, f.output)
 
         aws_session_mock.return_value.delete_object_in_bucket.assert_called_once()
         aws_session_mock.return_value.delete_object_in_bucket.assert_called_with(filename, bucket_name)
@@ -71,13 +71,11 @@ class DeleteObjectTest(TestCase):
         filename = 'aaa.txt'
         bucket_name = 'aarrrp'
 
-        f = io.StringIO()
-        with redirect_stdout(f):
+        with self.assertLogs('delete_object_in_s3', level='INFO') as f:
             delete_main([self.command_name, filename, bucket_name])
 
-        expected_answer = 'An error occurred ({0}) when calling the delete operation: {1}'.format(
-            error_response['Error']['Code'], error_response['Error']['Message'])
-        self.assertIn(expected_answer, f.getvalue())
+        expected_answer = 'ERROR:delete_object_in_s3:An error occurred (403) when calling the delete operation: forbidden'
+        self.assertIn(expected_answer, f.output)
 
         aws_session_mock.return_value.delete_object_in_bucket.assert_called_once()
         aws_session_mock.return_value.delete_object_in_bucket.assert_called_with(filename, bucket_name)
@@ -390,7 +388,8 @@ class DeleteBucketTest(TestCase):
         with self.assertLogs('delete_bucket_from_s3', level='INFO') as f:
             delete_bucket_main([self.command_name, bucket_name])
 
-        expected_answer = 'ERROR:delete_bucket_from_s3:An error occurred (403) when calling the deleting operation: forbidden'
+        expected_answer = 'ERROR:delete_bucket_from_s3:An error occurred (403) when calling the deleting operation: ' \
+                          'forbidden '
         self.assertIn(expected_answer, f.output)
 
         delete_bucket.assert_called_once()
@@ -439,7 +438,8 @@ class MoveBucketTest(TestCase):
         with self.assertLogs('move_bucket_from_s3', level='INFO') as f:
             move_bucket_main([self.command_name, source, target])
 
-        expected_answer = 'ERROR:move_bucket_from_s3:An error occurred (403) when calling the moving operation: forbidden'
+        expected_answer = 'ERROR:move_bucket_from_s3:An error occurred (403) when calling the moving operation: ' \
+                          'forbidden '
         self.assertIn(expected_answer, f.output)
 
         move_files_from_bucket_to_bucket.assert_called_once()


### PR DESCRIPTION
# Nuevos Comandos
Se agregan dos comandos nuevos que permiten mover archivos entre buckets y eliminar un bucket en su totalidad.

## delete_bucket_from_s3
Comando que permite eliminar un bucket. Este se encarga de eliminar cada archivo del bucket para posteriormente eliminarlo.

## move_bucket_from_s3
Comando que permite mover archivos entre buckets. Por defecto mueve todos los archivos desde el bucket origen al bucket destino. 

Como parámetros opcionales se permite agregar una lista de archivos a ser movidos y una lista de filtros de extensiones a mover.

